### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/wind-forecast-api.yml
+++ b/.github/workflows/wind-forecast-api.yml
@@ -7,7 +7,7 @@ env:
   AZURE_WEBAPP_NAME: wind-forecast-api
   AZURE_WEBAPP_PACKAGE_PATH: ./publish
   CONFIGURATION: Release
-  DOTNET_CORE_VERSION: 7.0.x
+  DOTNET_CORE_VERSION: 8.0.x
   WORKING_DIRECTORY: .
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wind-forecast-api
 
-I've created a very basic Web API I use to obtain notifications when there is a risk of rain or strong wind gust. I use it to be notified so I can remove outside sails when there is a significant risk.
+I've created a very basic Web API I use to obtain notifications when there is a risk of rain or strong wind gust. I use it to be notified so I can remove outside sails when there is a significant risk. The project now targets **.NET 8 LTS**.
 
 I made it for my own usage so if you want to use it you'll have to adapt code a little bit. For instance, the forecast concerns only tomorrow in Montpellier (France) city.
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -80,7 +80,11 @@ namespace wind_forecast_api
                 app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "wind_forecast_api v1"));
             }
 
-            //app.UseHttpsRedirection();
+            if (!env.IsDevelopment())
+            {
+                app.UseHsts();
+                app.UseHttpsRedirection();
+            }
 
             app.UseRouting();
             

--- a/wind-forecast-api.csproj
+++ b/wind-forecast-api.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>wind_forecast_api</RootNamespace>
     <UserSecretsId>3853aa39-6d6d-4bb2-8787-31d14011253a</UserSecretsId>
     <Version>2.0.0</Version>
     <NeutralLanguage></NeutralLanguage>
-    <PackageReleaseNotes>Updated to .NET 7</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 8</PackageReleaseNotes>
     <Platforms>AnyCPU;ARM32</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
-    <PackageReference Include="Lib.AspNetCore.WebPush" Version="2.2.2" />
-    <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.2.0" />
+    <PackageReference Include="Lib.AspNetCore.WebPush" Version="2.3.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update target framework to .NET 8
- bump package versions
- mention .NET 8 in README
- enable HTTPS redirection and HSTS in production

## Testing
- `dotnet build wind-forecast-api.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b59abc7e883208a71d682961b0f88